### PR TITLE
Fix scoped associations with empty loaded records

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -225,7 +225,7 @@ module ActiveRecord
         if loaded? || @association_ids || reflection.has_cached_counter?
           size.zero?
         else
-          target.empty? && !scope.exists?
+          target.select(&:new_record?).empty? && !scope.exists?
         end
       end
 
@@ -320,7 +320,6 @@ module ActiveRecord
         #   * Otherwise, attributes should have the value found in the database
         def merge_target_lists(persisted, memory)
           return persisted if memory.empty?
-          return memory    if persisted.empty?
 
           persisted.map! do |record|
             if mem_record = memory.delete(record)

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -84,7 +84,10 @@ module ActiveRecord
           # If there's nothing in the database and @target has no new records
           # we are certain the current target is an empty array. This is a
           # documented side-effect of the method that may avoid an extra SELECT.
-          loaded! if count == 0
+          if count == 0 && target.select(&:new_record?).empty?
+            self.target = []
+            loaded!
+          end
 
           [association_scope.limit_value, count].compact.min
         end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -32,6 +32,8 @@ require "models/discount"
 require "models/line_item"
 require "models/shipping_line"
 require "models/essay"
+require "models/member"
+require "models/membership"
 
 class AssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :developers_projects,
@@ -125,7 +127,7 @@ class AssociationsTest < ActiveRecord::TestCase
 end
 
 class AssociationProxyTest < ActiveRecord::TestCase
-  fixtures :authors, :author_addresses, :posts, :categorizations, :categories, :developers, :projects, :developers_projects
+  fixtures :authors, :author_addresses, :posts, :categorizations, :categories, :developers, :projects, :developers_projects, :members
 
   def test_push_does_not_load_target
     david = authors(:david)
@@ -298,6 +300,37 @@ class AssociationProxyTest < ActiveRecord::TestCase
 
     assert_equal 1, david.thinking_posts.size
     assert_equal 1, david.thinking_posts.to_a.size
+  end
+
+  def test_target_merging_ignores_persisted_in_memory_records_when_loaded_records_are_empty
+    member = members(:blarpy_winkup)
+    assert_empty member.favorite_memberships
+
+    membership = member.favorite_memberships.create!
+    membership.update!(favorite: false)
+
+    assert_empty member.favorite_memberships.to_a
+  end
+
+  def test_empty_does_not_count_persisted_in_memory_records_when_loaded_records_are_empty
+    member = members(:blarpy_winkup)
+    assert_empty member.favorite_memberships
+
+    membership = member.favorite_memberships.create!
+    membership.update!(favorite: false)
+
+    assert_empty member.favorite_memberships
+  end
+
+  def test_size_differentiates_between_new_and_persisted_in_memory_records_when_loaded_records_are_empty
+    member = members(:blarpy_winkup)
+    assert_empty member.favorite_memberships
+
+    membership = member.favorite_memberships.create!
+    membership.update!(favorite: false)
+
+    assert_equal 0, member.favorite_memberships.size
+    assert_empty member.favorite_memberships
   end
 end
 

--- a/activerecord/test/models/destroy_async_parent.rb
+++ b/activerecord/test/models/destroy_async_parent.rb
@@ -4,12 +4,12 @@
    self.primary_key = "parent_id"
 
    has_one :dl_keyed_has_one, dependent: :destroy_async,
-     foreign_key: :destroy_async_parent_id, primary_key: :parent_id
+     foreign_key: :destroy_async_parent_id
    has_many :dl_keyed_has_many, dependent: :destroy_async,
-     foreign_key: :many_key, primary_key: :parent_id
+     foreign_key: :many_key
    has_many :dl_keyed_join, dependent: :destroy_async,
-     foreign_key: :destroy_async_parent_id, primary_key: :joins_key
+     foreign_key: :destroy_async_parent_id
    has_many :dl_keyed_has_many_through,
      through: :dl_keyed_join, dependent: :destroy_async,
-     foreign_key: :dl_has_many_through_key_id, primary_key: :through_key
+     foreign_key: :dl_has_many_through_key_id
  end


### PR DESCRIPTION
### Summary
This PR addresses a few bugs found while working in our Rails application. They impact associations with a scope, like so:
```ruby
class Coupon < ActiveRecord::Base
  has_many :coupon_redemptions, -> { where(expired: false) }
end
```

These bugs are caused by assuming that the list of in-memory targets have not been persisted to the database when the list of persisted records is empty.

Specifically, these are the 3 issues addressed:
1. `assert_empty` with `.to_a` at the end.
```ruby
coupon = Coupon.create!
coupon_redemption = coupon.coupon_redemptions.create!
coupon_redemption.update!(expired: true)
assert_empty coupon.coupon_redemptions.to_a
```
This test used to fail because [`CollectionAssociation#merge_target_lists` would return the in-memory records if no persisted records came back from the database](https://github.com/rails/rails/blob/5fdbd217d18302cd277f80a9ba7fd567844ec324/activerecord/lib/active_record/associations/collection_association.rb#L323). After this commit the test will pass because `merge_target_lists` will filter out any persisted records from the in-memory list.

2. `assert_empty` **without** `.to_a` at the end.
```ruby
coupon = Coupon.create!
coupon_redemption = coupon.coupon_redemptions.create!
coupon_redemption.update!(expired: true)
assert_empty coupon.coupon_redemptions
```
This test used to fail because [`CollectionAssociation#empty?` did not account for persisted records in memory before checking for emptiness](https://github.com/rails/rails/blob/5fdbd217d18302cd277f80a9ba7fd567844ec324/activerecord/lib/active_record/associations/collection_association.rb#L228). This commit adds that scenario.

3. Calling `.size` before `assert_empty`
```ruby
coupon = Coupon.create!
coupon_redemption = coupon.coupon_redemptions.create!
coupon_redemption.update!(expired: true)
assert_equal 0, coupon.coupon_redemptions.size
assert_empty coupon.coupon_redemptions
```
This test used to fail through a more complex path. When asserting `coupon.coupon_redemptions.size` [the target gets marked as loaded as part of `HasManyAssociation#count_records`](https://github.com/rails/rails/blob/5fdbd217d18302cd277f80a9ba7fd567844ec324/activerecord/lib/active_record/associations/has_many_association.rb#L85). This is an issue as the target value is not empty when we expect it to be. [The comment in the method above](https://github.com/rails/rails/blob/5fdbd217d18302cd277f80a9ba7fd567844ec324/activerecord/lib/active_record/associations/has_many_association.rb#L82-L84) validates that.
After this commit, the test will pass because we set the target to an empty array if target has no new records.

---

<details>
<summary>Reproduction script with a failing test for each individual issue</summary>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

ActiveRecord::Schema.define do
  create_table :coupons, force: true do |t|
  end

  create_table :coupon_redemptions, force: true do |t|
    t.integer :coupon_id
    t.boolean :expired, default: false
  end
end

class Coupon < ActiveRecord::Base
  has_many :coupon_redemptions, -> { where(expired: false) }
end

class CouponRedemption < ActiveRecord::Base
  belongs_to :coupon
end

class BugTest < Minitest::Test
  def test_loading_associations
    coupon = Coupon.create!
    coupon_redemption = coupon.coupon_redemptions.create!
    coupon_redemption.update!(expired: true)

    assert_empty coupon.coupon_redemptions.to_a
  end

  def test_associations_not_loaded
    coupon = Coupon.create!
    coupon_redemption = coupon.coupon_redemptions.create!
    coupon_redemption.update!(expired: true)

    assert_empty coupon.coupon_redemptions
  end

  def test_associations_size
    coupon = Coupon.create!
    coupon_redemption = coupon.coupon_redemptions.create!
    coupon_redemption.update!(expired: true)

    assert_equal 0, coupon.coupon_redemptions.size
    assert_empty coupon.coupon_redemptions
  end
end
```
</details>

### Other Information

Removing this guard clause should not affect performance since `persisted` is empty, so the `map!` won't do anything.
```diff
def merge_target_lists(persisted, memory)
  return persisted if memory.empty?
- return memory if persisted.empty?
  
  persisted.map! do |record|
    # ...
  end
end
```
