### PR TITLE
Changelog entry for routes source location

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Include source location in routes extended view.
+
+    ```
+    bin/rails routes --expanded
+
+    [...]
+    --[ Route 14 ]-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    Prefix            | new_gist
+    Verb              | GET
+    URI               | /gist(.:format)
+    Controller#Action | gists/gists#new
+    Source Location   | config/routes/gist.rb:3
+    ```
+
+    *Luan Vieira, John Hawthorn and Daniel Colson*
+
 *   Add `without` as an alias of `except` on `ActiveController::Parameters`.
 
     *Hidde-Jan Jongsma*


### PR DESCRIPTION
We added "Source Location" to the extended routes list view in https://github.com/rails/rails/pull/47877.
This adds a CHANGELOG entry for it.
