### PR TITLE
Failing test for scoped association with params

### DIFF
--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -469,6 +469,12 @@ module ActiveRecord
       assert_equal authors(:david), authors.first
     end
 
+    def test_where_on_association_with_scoped_relation_taking_parameters_lv
+      authors = Author.where(different_post: Post.all)
+      assert_equal 1, authors.count
+      assert_equal authors(:david), authors.first
+    end
+
     def test_where_with_strong_parameters
       author = authors(:david)
       params = ProtectedParams.new(name: author.name)

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -77,6 +77,8 @@ class Author < ActiveRecord::Base
 
   has_many :thinking_posts, -> { where(title: "So I was thinking") }, dependent: :delete_all, class_name: "Post"
   has_many :welcome_posts, -> { where(title: "Welcome to the weblog") }, class_name: "Post"
+  has_one :different_post, -> (post) { yet_another_post(post) }, class_name: "Post"
+  scope :yet_another_post, -> (post) { where(title: post.title) }
 
   has_many :welcome_posts_with_one_comment,
            -> { where(title: "Welcome to the weblog").where(comments_count: 1) },


### PR DESCRIPTION
This change generates the following test failure:
```
Error:
ActiveRecord::WhereTest#test_where_on_association_with_scoped_relation_taking_parameters_lv:
ArgumentError: wrong number of arguments (given 0, expected 1)
    /Users/luan/projects/rails/activerecord/test/models/author.rb:80:in `block in <class:Author>'
    /Users/luan/projects/rails/activerecord/lib/active_record/relation/spawn_methods.rb:50:in `instance_exec'
    /Users/luan/projects/rails/activerecord/lib/active_record/relation/spawn_methods.rb:50:in `merge!'
    /Users/luan/projects/rails/activerecord/lib/active_record/relation/spawn_methods.rb:37:in `merge'
    /Users/luan/projects/rails/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb:30:in `ids'
    /Users/luan/projects/rails/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb:18:in `queries'
    /Users/luan/projects/rails/activerecord/lib/active_record/relation/predicate_builder.rb:107:in `block in expand_from_hash'
    /Users/luan/projects/rails/activerecord/lib/active_record/relation/predicate_builder.rb:80:in `each'
    /Users/luan/projects/rails/activerecord/lib/active_record/relation/predicate_builder.rb:80:in `flat_map'
    /Users/luan/projects/rails/activerecord/lib/active_record/relation/predicate_builder.rb:80:in `expand_from_hash'
    /Users/luan/projects/rails/activerecord/lib/active_record/relation/predicate_builder.rb:25:in `build_from_hash'
    /Users/luan/projects/rails/activerecord/lib/active_record/relation/query_methods.rb:1520:in `build_where_clause'
    /Users/luan/projects/rails/activerecord/lib/active_record/relation/query_methods.rb:937:in `where!'
    /Users/luan/projects/rails/activerecord/lib/active_record/relation/query_methods.rb:932:in `where'
    /Users/luan/projects/rails/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb:97:in `where'
    /Users/luan/projects/rails/activerecord/lib/active_record/querying.rb:23:in `where'
    test/cases/relation/where_test.rb:473:in `test_where_on_association_with_scoped_relation_taking_parameters_lv'
```

Introduced by this change: https://github.com/rails/rails/pull/48487/commits/8d520e03595f9876d2f71809b48c11c46ec5a47c

